### PR TITLE
Added message logging level control to tmp/log/si.log output.

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -24,7 +24,7 @@ export.pdf.rightmargin              = 15
 export.pdf.topmargin                = 15
 export.pdf.bottommargin             = 15
 
-version.name                        = 2016.1.001
+version.name                        = 2016.1.002
 
 local.locale                        = en_US
 local.precision                     = 2
@@ -49,6 +49,11 @@ phpSettings.display_startup_errors  = 1
 phpSettings.display_errors          = 1
 phpSettings.log_errors              = 0
 phpSettings.error_log               = tmp/log/php.log
+
+; Logs in tmp/log/si.log. Set to the desired level for log detail.
+; The higher the number, the more information will be logged.
+; DEBUG(7),INFO(6),NOTICE(5),WARN(4),ERR(3),CRIT(2),ALERT(1),EMERG(0)
+zend.logger_level                   = EMERG 
 
 ; Explicity confirm delete of line items from invoices? (yes/no)
 confirm.deleteLineItem              = no

--- a/include/init.php
+++ b/include/init.php
@@ -48,7 +48,6 @@ if (!is_writable($logFile)) {
 }
 $writer = new Zend_Log_Writer_Stream($logFile);
 $logger = new Zend_Log($writer);
-if ($logger) {} // Show variable as used.
 /* *************************************************************
  * log file - end
  * *************************************************************/
@@ -62,6 +61,44 @@ global $environment;
 
 // added 'true' to allow modifications from db
 $config = new Zend_Config_Ini("./" . CONFIG_FILE_PATH, $environment, true);
+$logger_level = (isset($config->zend->logger_level) ? strtoupper($config->zend->logger_level) : 'EMERG');
+switch($logger_level) {
+    case 'DEBUG':
+        $level = Zend_Log::DEBUG;
+        break;
+    
+    case 'INFO':
+        $level = Zend_Log::INFO;
+        break;
+
+    case 'NOTICE':
+        $level = Zend_Log::NOTICE;
+        break;
+
+    case 'WARN':
+        $level = Zend_Log::WARN;
+        break;
+
+    case 'ERR':
+        $level = Zend_Log::ERR;
+        break;
+
+    case 'CRIT':
+        $level = Zend_Log::CRIT;
+        break;
+
+    case 'ALERT':
+        $level = Zend_Log::ALERT;
+        break;
+
+    case 'EMERG':
+    default:
+        $level = Zend_Log::EMERG;
+        break;
+}
+$filter = new Zend_Log_Filter_Priority($level);
+$logger->addFilter($filter);
+
 try {
     $dbInfo = new DbInfo(CONFIG_FILE_PATH, "production");
 } catch (PdoDbException $pde) {

--- a/include/sql_queries.php
+++ b/include/sql_queries.php
@@ -26,7 +26,7 @@ try {
 // Cannot redfine LOGGING (withour PHP PECL runkit extension) since already true in define.php
 // Ref: http://php.net/manual/en/function.runkit-method-redefine.php
 // Hence take from system_defaults into new variable
-// Initialise so that while it is being evaluated, it prevents logging
+// Initialize so that while it is being evaluated, it prevents logging
 $can_log = false;
 $can_chk_log = (LOGGING && (isset($auth_session->id) && $auth_session->id > 0) && getDefaultLoggingStatus());
 $can_log = $can_chk_log;


### PR DESCRIPTION
Added debug logging feature that can be turned on and off through
setting of new value in the config/config.php file. If you use
custom.config.php (as recommended), copy the "zend.logger_level" line
and its comments from the config/config.php file from this update. The
default level is EMERG. The most detailed level is DEBUG which should be
used if you are having issues and no error is generated.