### PR TITLE
Add si_index initial record required for sample data set up.

### DIFF
--- a/databases/json/sample_data.json
+++ b/databases/json/sample_data.json
@@ -193,6 +193,17 @@
 			}
         ]
     ,
+    "si_index":
+        [
+            {
+                "id":"1",
+                "node":"invoice",
+                "sub_node":"1",
+                "sub_node_2":"0",
+                "domain_id":"1"
+            }
+        ]
+    ,
 	"si_invoice_items":
         [
             {


### PR DESCRIPTION
Set up using the sample data was not incrementing the invoice number
consistent with data installed because the si_index table was not set
up.