### PR TITLE
Leave the age empty on invoice list for future dated invoices.

### DIFF
--- a/include/class/Invoice.php
+++ b/include/class/Invoice.php
@@ -486,7 +486,7 @@ class Invoice {
         if ($noage_type) {
             $pdoDb->setSelectList("'' AS Age, '' AS aging");
         } else {
-            $fn = new FunctionStmt("IF", "(owing = 0 OR owing < 0), 0, DateDiff(now(), date)");
+            $fn = new FunctionStmt("IF", "(owing = 0 OR owing < 0 OR DateDiff(now(), date) < 0), 0, DateDiff(now(), date)");
             $se = new Select($fn, null, null, "Age");
             $pdoDb->addToSelectStmts($se);
 


### PR DESCRIPTION
Remove misleading information from the Age field of the list of invoices or any place the age might be referenced.