### PR TITLE
comment out  last line  as file doesn't exist

### DIFF
--- a/include/init.php
+++ b/include/init.php
@@ -346,4 +346,4 @@ $siUrl = getURL();
  * appended to the config array, instead of replacing it
  * (NOTE: NOT TESTED!)
  * *************************************************************/
-include_once ("include/class/BackupDb.php");
+//include_once ("include/class/BackupDb.php");


### PR DESCRIPTION
include_once ("include/class/BackupDb.php");

This file no longer exists in the class directory