### PR TITLE
Update Smtp.php

### DIFF
--- a/library/Zend/Mail/Protocol/Smtp.php
+++ b/library/Zend/Mail/Protocol/Smtp.php
@@ -203,7 +203,10 @@ class Zend_Mail_Protocol_Smtp extends Zend_Mail_Protocol_Abstract
         if ($this->_secure == 'tls') {
             $this->_send('STARTTLS');
             $this->_expect(220, 180);
-            if (!stream_socket_enable_crypto($this->_socket, true, STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT)) {
+            if (!stream_socket_enable_crypto($this->_socket, true,
+                             STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT |
+                             STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT |
+                             STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT)) {
                 /**
                  * @see Zend_Mail_Protocol_Exception
                  */

--- a/library/Zend/Mail/Protocol/Smtp.php
+++ b/library/Zend/Mail/Protocol/Smtp.php
@@ -203,7 +203,7 @@ class Zend_Mail_Protocol_Smtp extends Zend_Mail_Protocol_Abstract
         if ($this->_secure == 'tls') {
             $this->_send('STARTTLS');
             $this->_expect(220, 180);
-            if (!stream_socket_enable_crypto($this->_socket, true, STREAM_CRYPTO_METHOD_TLS_CLIENT)) {
+            if (!stream_socket_enable_crypto($this->_socket, true, STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT)) {
                 /**
                  * @see Zend_Mail_Protocol_Exception
                  */


### PR DESCRIPTION
This works for me to use TLSv1.2 when sending an email

But perhaps need to keep legacy support as well, and then this should be config option. What do you think?