### PR TITLE
permitting config fields with equals (=) in the string

### DIFF
--- a/include/class/DbInfo.php
+++ b/include/class/DbInfo.php
@@ -81,7 +81,7 @@ class DbInfo {
             $line = trim($secure_info[$i]);
             if (strstr($line,"=") === false) break;
 
-            $parts = explode("=", $line);
+            $parts = explode("=", $line, 2);
             if (count($parts) != 2) break;
 
             $pieces = MyCrypt::unjoin($line, $prefix);

--- a/include/class/MyCrypt.php
+++ b/include/class/MyCrypt.php
@@ -68,7 +68,7 @@ class MyCrypt {
      */
     public static function unjoin($line, $prefix) {
         $line = preg_replace('/^(.*);.*$/', '$1', $line);
-        $pieces = explode("=", $line);
+        $pieces = explode("=", $line, 2);
         if (count($pieces) != 2) return array("","");
 
         $parts = explode(".", $pieces[0]);


### PR DESCRIPTION
If a config parameter contains an equals sign, don't split it out.  `explode` can be constrained to the first `=` as a delimiter only.