### PR TITLE
Missing template error fix

### DIFF
--- a/Inc/Claz/ApiAuth.php
+++ b/Inc/Claz/ApiAuth.php
@@ -12,8 +12,10 @@ class ApiAuth
     {
         // API calls don't use the auth module
         if ($module != 'api') {
-            session_name('SiAuth');
-            session_start();
+            if (PHP_SESSION_ACTIVE !== session_status()){
+                session_name('SiAuth');
+                session_start();
+            }
             $sessionId = $_SESSION['id'] ?? 0;
             $getId = 0 ?? $_GET['id'];
             Log::out("ApiAuth::authenticate() - sessionId[$sessionId] getId[$getId] module[$module] view[$view]");

--- a/Inc/Claz/DomainId.php
+++ b/Inc/Claz/DomainId.php
@@ -16,8 +16,10 @@ class DomainId
      */
     public static function get(?int $domainId = null): int
     {
-        session_name('SiAuth');
-        session_start();
+        if (PHP_SESSION_ACTIVE !== session_status()){
+            session_name('SiAuth');
+            session_start();
+        }
         // default when session value absent - fake auth, whether auth needed or not
         $domId = 1;
 

--- a/Inc/Claz/Export.php
+++ b/Inc/Claz/Export.php
@@ -219,6 +219,13 @@ class Export
                     $templateDir = "templates/invoices/$template";
                     $css = $siUrl . "templates/invoices/$template/style.css";
 
+                    if(!$template || !\file_exists($smarty->getTemplateDir()[0] . $templateDir )){
+                        Log::out('Template specified in SI Settings does not exist. Falling back to default template.');
+                        $template = 'default';
+                        $templateDir = "templates/invoices/$template";
+                        $css = $siUrl . "templates/invoices/$template/style.css";
+                    }
+
                     $pageActive = "invoices";
                     $smarty->assign('pageActive', $pageActive);
 
@@ -249,6 +256,8 @@ class Export
                     }
 
                     $data = $smarty->fetch("templates/invoices/$template/template.tpl");
+
+
 
                     // Restore configured locale
                     if (!empty($origLocale)) {

--- a/Inc/Claz/PdoDb.php
+++ b/Inc/Claz/PdoDb.php
@@ -809,7 +809,7 @@ class PdoDb
                                     if (!empty($columns[$nam])) {
                                         $columns[$nam] .= ":";
                                     }
-                                    $columns[$nam] .= strtoupper($row2['constraint_name']);
+                                    $columns[$nam] .= isset($row2['constraint_name']) ? strtoupper($row2['constraint_name']) : '';
                                 }
                             }
                         }

--- a/modules/products/manage.php
+++ b/modules/products/manage.php
@@ -14,7 +14,11 @@ $defaults = SystemDefaults::loadValues();
 $smarty->assign("defaults", $defaults);
 
 $products = Product::manageTableInfo();
-$data = json_encode(['data' => $products]);
+try {
+    $data = json_encode(['data' => $products], JSON_THROW_ON_ERROR);
+} catch (\Exception $e) {
+    var_dump($e);
+}
 if (file_put_contents("public/data.json", $data) === false) {
     exit("Unable to create public/data.json file");
 }

--- a/modules/products/manage.php
+++ b/modules/products/manage.php
@@ -13,11 +13,11 @@ Util::directAccessAllowed();
 $defaults = SystemDefaults::loadValues();
 $smarty->assign("defaults", $defaults);
 
-$products = Product::manageTableInfo();
+$products = mb_convert_encoding(Product::manageTableInfo(), 'UTF-8');
 try {
     $data = json_encode(['data' => $products], JSON_THROW_ON_ERROR);
 } catch (\Exception $e) {
-    var_dump($e);
+    error_log($e->getMessage());
 }
 if (file_put_contents("public/data.json", $data) === false) {
     exit("Unable to create public/data.json file");


### PR DESCRIPTION
See https://github.com/redcuillin/simpleinvoices/issues/8

If the user deletes a custom template for any reason, without first making a change in the settings, displaying/printing invoices becomes impossible, and no clear explanation is given for why key functionality is broken.

This fix adds an explanatory log entry and loads the default template instead so that SimpleInvoices is still usable.