### PR TITLE
redcuillin/simpleinvoices issue 8

### DIFF
--- a/Inc/Claz/Export.php
+++ b/Inc/Claz/Export.php
@@ -219,6 +219,12 @@ class Export
                     $templateDir = "templates/invoices/$template";
                     $css = $siUrl . "templates/invoices/$template/style.css";
 
+                    if(!$template || !\file_exists($smarty->getTemplateDir()[0] . $templateDir )){
+                        Log::out('Template specified in SI Settings does not exist. Falling back to default template.');
+                        $templateDir = "templates/invoices/default";
+                        $css = $siUrl . "templates/invoices/default/style.css";
+                    }
+
                     $pageActive = "invoices";
                     $smarty->assign('pageActive', $pageActive);
 


### PR DESCRIPTION
See https://github.com/redcuillin/simpleinvoices/issues/8

If the user deletes a custom template for any reason, without first making a change in the settings, displaying/printing invoices becomes impossible, and no clear explanation is given for why key functionality is broken.

This fix adds an explanatory log entry and loads the default template instead so that SimpleInvoices is still usable.
Treating as seperate PR to previous encoding PR, in case previous PR not desirable.