### PR TITLE
Use built-in error-reporting to improve installation and DB connection errors.

### DIFF
--- a/Inc/Claz/Config.php
+++ b/Inc/Claz/Config.php
@@ -40,6 +40,10 @@ class Config
             self::updateConfig();
         }
 
+        if (!\file_exists("./$configFile")) {
+            SiError::out('generic', 'Config::init()', "Ini file does not exist: $configFile");
+        }
+
         $config = parse_ini_file("./$configFile", true);
         if ($config === false) {
             SiError::out('generic', 'Config::init()', "Unable to parse ini file: $configFile");
@@ -56,7 +60,9 @@ class Config
     {
         // Create custom.config.ini file if it doesn't already exist
         if (!file_exists("./" . self::CUSTOM_CONFIG_FILE)) {
-            copy("./" . self::CONFIG_FILE, "./" . self::CUSTOM_CONFIG_FILE);
+            if (!copy("./" . self::CONFIG_FILE, "./" . self::CUSTOM_CONFIG_FILE)) {
+                SiError::out('install', 'Config::update_config()', 'Unable to copy ' . self::CONFIG_FILE . ' to ' . self::CUSTOM_CONFIG_FILE);
+            }
         }
     }
 
@@ -285,5 +291,4 @@ class Config
             unlink($filenameNew);
         }
     }
-
 }

--- a/Inc/Claz/Setup.php
+++ b/Inc/Claz/Setup.php
@@ -38,26 +38,7 @@ class Setup
                 $this->pdoDb = new PdoDb($this->configIni);
                 $this->pdoDbAdmin = new PdoDb($this->configIni);
             } catch (PdoDbException $pde) {
-                if (preg_match('/.*{dbname|password|username}/', $pde->getMessage())) {
-                    echo "<h1 style='font-weight:bold;color:red;'>Initial setup. Follow the following instructions:</h1>";
-                    echo "<ol>";
-                    echo "  <li>Make a mySQL compatible database with a user that has full access to it.</li>";
-                    echo "  <li>In the \"config\" directory, copy the <b>config.ini</b> file to <b>custom.config.ini</b></li>";
-                    echo "  <li>Modify the database settings in the <b>custom.config.ini</b> file for the database made in step 1.";
-                    echo "    <ul>";
-                    echo "      <li>Set <b>databaseDbname</b> to the name of the database.";
-                    echo "      <li>Set <b>databaseUsername</b> to the username of the database administrator.</li>";
-                    echo "      <li>Set <b>databasePassword</b> to the database administrator password. Note you might need to include this in single quotes.</li>";
-                    echo "    </ul>";
-                    echo "  </li>";
-                    echo "  <li>In your browser, execute the command to access SI again and follow the instructions.</li>";
-                    echo "</ol>";
-                } else {
-                    echo "<h1 style='font-weight:bold;color:red;'>";
-                    echo "  " . $pde->getMessage() . " (Error code: {$pde->getCode()})";
-                    echo "</h1>";
-                }
-
+                SiError::out('dbConnection', $pde->getMessage());
                 throw new PdoDbException($pde->getMessage());
             }
         }
@@ -69,7 +50,6 @@ class Setup
         ini_set('display_errors', $this->configIni['phpSettingsDisplayErrors']);
         ini_set('log_errors', $this->configIni['phpSettingsLogErrors']);
         ini_set('error_log', $this->configIni['phpSettingsErrorLog']);
-
     }
 
     public function getConfigIni(): array
@@ -86,5 +66,4 @@ class Setup
     {
         return $this->pdoDbAdmin;
     }
-
 }

--- a/Inc/Claz/SiError.php
+++ b/Inc/Claz/SiError.php
@@ -49,158 +49,158 @@ class SiError
         switch ($type) {
             case "generic":
                 $mess = "<br />===========================================" .
-                        "<br />SimpleInvoices $info1 error" .
-                        "<br />===========================================" .
-                        "<br />" .
-                        "<br />$info2";
+                    "<br />SimpleInvoices $info1 error" .
+                    "<br />===========================================" .
+                    "<br />" .
+                    "<br />$info2";
                 break;
 
             case "notWritable":
                 $mess = "<br />===========================================" .
-                        "<br />SimpleInvoices error" .
-                        "<br />===========================================" .
-                        "<br />The " . $info1 . " <b>" . $info2 . "</b> has to be writable";
+                    "<br />SimpleInvoices error" .
+                    "<br />===========================================" .
+                    "<br />The " . $info1 . " <b>" . $info2 . "</b> has to be writable";
                 break;
 
             case "dbConnection":
                 $mess = "<br />===========================================" .
-                        "<br />SimpleInvoices database connection problem" .
-                        "<br />===========================================" .
-                        "<br />" .
-                        "<br />Could not connect to the SimpleInvoices database" .
-                        "<br />" .
-                        "<br />For information on how to fix this, refer to the following database error: " .
-                        "<br />--> <b>$info1</b>" .
-                        "<br />" .
-                        "<br />If this is an &quot;Access denied&quot; error please enter the correct database " .
-                              "connection details config/custom.config.ini." .
-                        "<br />" .
-                        "<br /><b>Note:</b> If you are installing SimpleInvoices please follow the below steps:" .
-                        "<ol>" .
-                            "<li>Create a blank MySQL database (cPanel or myPHPAdmin). Defined a DB Admin username " .
-                                "with full access to this database. Assign a password to this DB Admin user.</li>" .
-                            "<li>Enter the correct database connection details in the config/custom.config.ini file.</li>" .
-                            "<li>Refresh this page</li>" .
-                        "</ol>" .
-                        "<br />===========================================";
+                    "<br />SimpleInvoices database connection problem" .
+                    "<br />===========================================" .
+                    "<br />" .
+                    "<br />Could not connect to the SimpleInvoices database" .
+                    "<br />" .
+                    "<br />For information on how to fix this, refer to the following database error: " .
+                    "<br />--> <b>$info1</b>" .
+                    "<br />" .
+                    "<br />If this is an &quot;Access denied&quot; error please enter the correct database " .
+                    "connection details config/custom.config.ini." .
+                    "<br />" .
+                    "<br /><b>Note:</b> If you are installing SimpleInvoices please follow the below steps:" .
+                    "<ol>" .
+                    "<li>Create a blank MySQL database (cPanel or myPHPAdmin). Define a DB Admin username " .
+                    "with full access to this database. Assign a password to this DB Admin user.</li>" .
+                    "<li>Enter the correct database connection details in the config/custom.config.ini file.</li>" .
+                    "<li>Refresh this page</li>" .
+                    "</ol>" .
+                    "<br />===========================================";
                 break;
 
             case "dbError":
                 $mess = "<br />===========================================" .
-                        "<br />SimpleInvoices database error" .
-                        "<br />===========================================" .
-                        "<br />" .
-                        "<br />>$info1 - Error: $info2";
+                    "<br />SimpleInvoices database error" .
+                    "<br />===========================================" .
+                    "<br />" .
+                    "<br />>$info1 - Error: $info2";
                 break;
 
             case "install":
                 $mess = "<div id='containter' class='col si_wrap'>" .
-                            "<div id='si_install_logo'>" .
-                                "<img src='templates/invoices/logos/simple_invoices_logo.png' alt='' class='si_install_logo' width='300'/>" .
-                            "</div>" .
-                            "<table style='width:50%'>" .
-                                "<tr>" .
-                                    "<th style='font-weight: bold;text-align:center;'>===========================================</th>" .
-                                "</tr>" .
-                                "<tr>" .
-                                    "<th style='font-weight: bold;text-align:center;'>SimpleInvoices database connection problem</th>" .
-                                "</tr>" .
-                                "<tr>" .
-                                    "<th style='font-weight: bold;text-align:center;'>===========================================</th>" .
-                                "</tr>" .
-                                "<tr>" .
-                                    "<th style='font-weight:normal;'>" .
-                                        "You&#39;ve reached this page because the name of the database in your " .
-                                        "configuration file has not been created. Please follow the following " .
-                                        "instructions before leaving this page." .
-                                        "<ol>" .
-                                            "<li>Using your database admin program, phpMyAdmin for MySQL, create a database " .
-                                                "preferably with UTF-8 collation. It can be named whatever you like but the " .
-                                                "name currently in the configuration file is, $dbname.</li>" .
-                                            "<li>Assign an administrative user and password to the database.</li>" .
-                                            "<li>Enter the database connection details in the <strong>" . Config::CUSTOM_CONFIG_FILE . "</strong> file." .
-                                                "The fields that need to be set are:" .
-                                                "<ul style='font-family:\"Lucida Console\", \"Courier New\"'>" .
-                                                    "<li>databaseHost&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;=&nbsp;localhost</li>" .
-                                                    "<li>databaseUsername&nbsp;=&nbsp;root</li>" .
-                                                    "<li>databasePassword&nbsp;=&nbsp;&#39;mypassword&#39;</li>" .
-                                                    "<li>databaseDbname&nbsp;&nbsp;&nbsp;=&nbsp;simple_invoices</li>" .
-                                                    "<li>databasePort&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;=&nbsp;3306</li>" .
-                                                "</ul>" .
-                                            "</li>" .
-                                            "<li>When you have completed these steps, simply refresh this page and follow " .
-                                                "the instructions to complete installation of SimpleInvoices.</li>" .
-                                        "</ol>" .
-                                    "</th>" .
-                                "</tr>" .
-                            "</table>" .
-                        "</div>";
+                    "<div id='si_install_logo'>" .
+                    "<img src='templates/invoices/logos/simple_invoices_logo.png' alt='' class='si_install_logo' width='300'/>" .
+                    "</div>" .
+                    "<table style='width:50%'>" .
+                    "<tr>" .
+                    "<th style='font-weight: bold;text-align:center;'>===========================================</th>" .
+                    "</tr>" .
+                    "<tr>" .
+                    "<th style='font-weight: bold;text-align:center;'>SimpleInvoices database connection problem</th>" .
+                    "</tr>" .
+                    "<tr>" .
+                    "<th style='font-weight: bold;text-align:center;'>===========================================</th>" .
+                    "</tr>" .
+                    "<tr>" .
+                    "<th style='font-weight:normal;'>" .
+                    "You&#39;ve reached this page because the name of the database in your " .
+                    "configuration file has not been created. Please follow the following " .
+                    "instructions before leaving this page." .
+                    "<ol>" .
+                    "<li>Using your database admin program, phpMyAdmin for MySQL, create a database " .
+                    "preferably with UTF-8 collation. It can be named whatever you like but the " .
+                    "name currently in the configuration file is, $dbname.</li>" .
+                    "<li>Assign an administrative user and password to the database.</li>" .
+                    "<li>Enter the database connection details in the <strong>" . Config::CUSTOM_CONFIG_FILE . "</strong> file." .
+                    "The fields that need to be set are:" .
+                    "<ul style='font-family:\"Lucida Console\", \"Courier New\"'>" .
+                    "<li>databaseHost&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;=&nbsp;localhost</li>" .
+                    "<li>databaseUsername&nbsp;=&nbsp;root</li>" .
+                    "<li>databasePassword&nbsp;=&nbsp;&#39;mypassword&#39;</li>" .
+                    "<li>databaseDbname&nbsp;&nbsp;&nbsp;=&nbsp;simple_invoices</li>" .
+                    "<li>databasePort&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;=&nbsp;3306</li>" .
+                    "</ul>" .
+                    "</li>" .
+                    "<li>When you have completed these steps, simply refresh this page and follow " .
+                    "the instructions to complete installation of SimpleInvoices.</li>" .
+                    "</ol>" .
+                    "</th>" .
+                    "</tr>" .
+                    "</table>" .
+                    "</div>";
                 break;
 
             case "PDO":
                 $mess = "<br />===========================================" .
-                        "<br />SimpleInvoices - PDO problem" .
-                        "<br />===========================================" .
-                        "<br />" .
-                        "<br />PDO is not configured in your PHP installation." .
-                        "<br />This means that SimpleInvoices can't be used." .
-                        "<br />" .
-                        "<br />To fix this please installed the pdo_mysql php extension." .
-                        "<br />If you are using a web host please email them and get them to" .
-                        "<br />install PDO for PHP with the MySQL extension" .
-                        "<br />" .
-                        "<br />===========================================" .
-                        "<br />";
+                    "<br />SimpleInvoices - PDO problem" .
+                    "<br />===========================================" .
+                    "<br />" .
+                    "<br />PDO is not configured in your PHP installation." .
+                    "<br />This means that SimpleInvoices can't be used." .
+                    "<br />" .
+                    "<br />To fix this please installed the pdo_mysql php extension." .
+                    "<br />If you are using a web host please email them and get them to" .
+                    "<br />install PDO for PHP with the MySQL extension" .
+                    "<br />" .
+                    "<br />===========================================" .
+                    "<br />";
                 break;
 
             case "sql":
                 $mess = "<br />===========================================" .
-                        "<br />SimpleInvoices - SQL problem" >
-                        "<br />===========================================" .
-                        "<br />" .
-                        "<br />The following sql statement:" .
-                        "<br />$info2" .
-                        "<br />" .
-                        "<br />had the following error code: $info1" .
-                        "<br />with the message of: \"$info2\"" .
-                        "<br />" .
-                        "<br />===========================================" .
-                        "<br />";
+                    "<br />SimpleInvoices - SQL problem" >
+                    "<br />===========================================" .
+                    "<br />" .
+                    "<br />The following sql statement:" .
+                    "<br />$info2" .
+                    "<br />" .
+                    "<br />had the following error code: $info1" .
+                    "<br />with the message of: \"$info2\"" .
+                    "<br />" .
+                    "<br />===========================================" .
+                    "<br />";
                 break;
 
             case "PDO_mysql_attr":
                 $mess = "<br />===========================================" .
-                        "<br />SimpleInvoices - PDO - MySQL problem" .
-                        "<br />===========================================" .
-                        "<br />" .
-                        "<br />Your SimpleInvoices installation can't use the" .
-                        "<br />database settings 'databaseUtf8'." .
-                        "<br />" .
-                        "<br />To fix this please edit config/config.ini and" .
-                        "<br />set 'databaseUtf8' to 'false'" .
-                        "<br />" .
-                        "<br />===========================================" .
-                        "<br />";
+                    "<br />SimpleInvoices - PDO - MySQL problem" .
+                    "<br />===========================================" .
+                    "<br />" .
+                    "<br />Your SimpleInvoices installation can't use the" .
+                    "<br />database settings 'databaseUtf8'." .
+                    "<br />" .
+                    "<br />To fix this please edit config/config.ini and" .
+                    "<br />set 'databaseUtf8' to 'false'" .
+                    "<br />" .
+                    "<br />===========================================" .
+                    "<br />";
                 break;
 
             case "PDO_not_mysql":
                 $mess = "<br />===========================================" .
-                        "<br />SimpleInvoices - PDO - MySQL problem" .
-                        "<br />===========================================" .
-                        "<br />" .
-                        "<br />Your SimpleInvoices installation can't use database types other than 'mysql'." .
-                        "<br />" .
-                        "<br />To fix this please edit the config/custom.config.ini file and set the " .
-                              "databaseAdapter to 'pdo_mysql' and databaseUtf8 to 'true'." .
-                        "<br />" .
-                        "<br />===========================================" .
-                        "<br />";
+                    "<br />SimpleInvoices - PDO - MySQL problem" .
+                    "<br />===========================================" .
+                    "<br />" .
+                    "<br />Your SimpleInvoices installation can't use database types other than 'mysql'." .
+                    "<br />" .
+                    "<br />To fix this please edit the config/custom.config.ini file and set the " .
+                    "databaseAdapter to 'pdo_mysql' and databaseUtf8 to 'true'." .
+                    "<br />" .
+                    "<br />===========================================" .
+                    "<br />";
                 break;
 
             default:
                 $mess = "<br />===========================================" .
-                        "<br />SimpleInvoices - Undefined Error Type ($type)" .
-                        "<br />===========================================";
+                    "<br />SimpleInvoices - Undefined Error Type ($type)" .
+                    "<br />===========================================";
                 break;
         }
         // @formatter:on


### PR DESCRIPTION
After a recent server change I was confused by the message I received when a database connection failed. The message implied I needed to install custom.config.inc, but it already existed.

I have modified Config.php and Setup.php to:

1. Catch missing custom.config.inc files and throw appropriate error.
2. Simplify Setup.php and remove inline HTML in the class while adding correct use of SiError.php class to show appropriate helpful messages to user if DB connections fail.